### PR TITLE
Grammar Change

### DIFF
--- a/src/chapters/chapter1.tex
+++ b/src/chapters/chapter1.tex
@@ -174,7 +174,7 @@
 	an exponent.  Thus, $\R\times \R\times \R$ can be written as $\R^3$, which is a set we've
 	seen before%
 	\footnote{
-		If you're scratching your head saying, ``I thought $\R^3$ was vectors in $3$-dimensional
+		If you're scratching your head saying, ``I thought $\R^3$ were vectors in $3$-dimensional
 		space.  How do we know that's the same thing as triples of real numbers?'' your mind
 		is keen.  This is a theorem of linear algebra.
 	}.


### PR DESCRIPTION
Changed "was" to "were" because it sounds better, but the grammar is ambiguous since R3 is singular but vectors is plural, so "was" is potentially correct