### PR TITLE
Updates to Chapter 2

### DIFF
--- a/src/chapters/chapter2.tex
+++ b/src/chapters/chapter2.tex
@@ -16,7 +16,7 @@ Whereas numbers allow us to specify relationships between single quantities
 relationships between geometric objects in space\footnote{
 	Though in this book we will treat vectors as intertwined with Euclidean
 	space, they are much more general.  For instance, someone's internet
-	browsing habits could be describe by a vector---the topics they
+	browsing habits could be described by a vector---the topics they
 	find most interesting might be the ``direction'' and the amount
 	of time they browse might be the ``magnitude.''
 }.  If we have two points, $P=(1,1)$ and $Q=(3,2)$, we specify the
@@ -490,7 +490,7 @@ problems.
 In three-dimensional space, the story is very similar.  Again, we imagine
 three perpendicular axes, the $x$, $y$, and $z$ axes.  
 To draw consistent
-pictures, we have an notion of a right-handed three-dimensional coordinate
+pictures, we have a notion of a right-handed three-dimensional coordinate
 system given by the \emph{right-hand rule}.
 
 \begin{center}
@@ -853,7 +853,7 @@ to be the ``true'' definition and consider the other definition a theorem.
 }.
 
 By switching between algebraic and geometric definitions, we can use the dot
-product to find quantities that are otherwise difficult.
+product to find quantities that are otherwise difficult to find.
 \begin{example}
 	Find the angle between the vectors $\vec v=(1,2,3)$ and $\vec w=(1,1,-2)$.
 
@@ -937,7 +937,7 @@ projections with the following diagram.
 	\end{tikzpicture}
 	\end{center}
 
-From the picture it appears that $\vec u$, $\Proj_{\vec v}\vec u$,
+From the picture, it appears that $\vec u$, $\Proj_{\vec v}\vec u$,
 and $\Perp_{\vec v}\vec u$ form a right triangle.  Of course, we shouldn't
 trust the picture. We should verify this mathematically.
 
@@ -1497,7 +1497,7 @@ Consider the lines described by
 \vec x &= t( -2, -6, 4) + ( 3, 1, 0 ).
 \end{align*}
 They have parallel directions since $( -2, -6, 4 ) = -2( 1, 3,-2 )$.
-Hence, in this case we say the lines are \emph{parallel}\index{parallel lines}.  (How can
+Hence, in this case, we say the lines are \emph{parallel}\index{parallel lines}.  (How can
 we be sure the lines are not the same?)
 \end{example}
 
@@ -1584,7 +1584,7 @@ suffice for defining $\mathcal P$ in vector form.
 \end{center}
 
 \begin{definition}[Vector form of a plane]
-	The plane $\mathcal P$ is describe in \emph{vector form} if there are
+	The plane $\mathcal P$ is described in \emph{vector form} if there are
 	three vectors $\vec d_1$, $\vec d_2$, and $\vec p$ where $\vec d_1,\vec d_2\neq \vec 0$
 	point in different directions and
 	\[


### PR DESCRIPTION
Line 19: misspelled word "described"
Line 493: confused article
Line 856: this is not grammatically incorrect or anything, I just feel that adding "to find" or "to evaluate" or something along these lines makes this statement more complete as it describes what is difficult with these quantities. However, it makes the sentence stylistically uglier as it's unnecessarily long. I think it could be rephrased to: "By switching between algebraic and geometric definitions, we can use the dot product to find otherwise difficult quantities." to achieve the same "completeness" without making it longer.
Line 940: Missing comma after an introductory phrase
Line 1500: Again, not a necessary comma, but I'd consider putting it there just because it sets the stage for your statement
Line 1587: a typo